### PR TITLE
Uno Yelling check

### DIFF
--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -55,11 +55,21 @@ void GameManager::ForceDrawNextPhase(int sumForNextDraw = 0)
 	_nextDraw += sumForNextDraw;
 }
 
-bool GameManager::FetchTurnCommands(std::shared_ptr<Player> player, PlayableCard playedCard, const std::string& aditionalCommand)
+bool GameManager::FetchTurnCommands(
+	std::shared_ptr<Player> player, PlayableCard playedCard, 
+	const std::string& aditionalCommand,
+	const std::string& unoWordCheck)
 {
-	if (_forcedDraw) {
+
+	if (_missedUno == player->Id) {
+		std::cout << "You missed UNO! You are forced to draw" << std::endl;
 		return false;
 	}
+	if (_forcedDraw) {
+		std::cout << "You are forced to draw this turn!" << std::endl;
+		return false;
+	}
+
 	Card card = _deck->GetCardMap()[playedCard.Id()];
 	
 	// Early type override parse
@@ -103,7 +113,20 @@ bool GameManager::FetchTurnCommands(std::shared_ptr<Player> player, PlayableCard
 	}
 
 	_turnCommands.emplace_back(std::make_shared<PlayCardCommand>(this, player, playedCard));
+
+	if (player->Hand.size() == 2){
+		if (unoWordCheck != "uno")
+		{
+			SetMissedUno(player->Id);
+		}
+	}
+
 	return true;
+}
+
+void GameManager::SetMissedUno(int playerId)
+{
+	_missedUno = playerId;
 }
 
 void GameManager::ExecuteTurn() 
@@ -138,6 +161,7 @@ void GameManager::DrawForPlayer(std::shared_ptr<Player> playerPtr)
 		playerPtr->Hand.back().SetPositionInHand(playerPtr->Hand.size() - 1);
 	}
 	_nextDraw = 0;
+	_missedUno = -1;
 	if (_forcedDraw) {
 		_forcedDraw = false;
 	}

--- a/src/Uno.cpp
+++ b/src/Uno.cpp
@@ -72,10 +72,6 @@ bool GetPlayerInputCommand(
 
 		std::string unoWordCheck;
 		iss >> unoWordCheck;
-		
-		if (toLowerCase(unoWordCheck) == "uno") {
-			// TODO treat uno word
-		}
 
 		if (cardPositionInHand >= playerPtr->Hand.size()) {
 			Log("Invalid Card Selected.");
@@ -83,7 +79,8 @@ bool GetPlayerInputCommand(
 		}
 
 		return gameManagerPtr->FetchTurnCommands(
-			playerPtr, playerPtr->Hand[cardPositionInHand], additionalCommand);
+			playerPtr, playerPtr->Hand[cardPositionInHand], 
+			additionalCommand, toLowerCase(unoWordCheck));
 	}
 	if (toLowerCase(commandType) == "draw") {
 		DrawCommand drawCommand { gameManagerPtr, playerPtr };

--- a/src/headers/GameManager.h
+++ b/src/headers/GameManager.h
@@ -18,7 +18,7 @@ public:
 	void DistributeCards();
 
 	// Fetch all commands for that turn
-	bool FetchTurnCommands(std::shared_ptr<Player> player, PlayableCard card, const std::string& aditionalCommand);
+	bool FetchTurnCommands(std::shared_ptr<Player> player, PlayableCard card, const std::string& aditionalCommand, const std::string& unoWordCheck);
 
 	// Execute the turn with all the actions pending for that turn
 	void ExecuteTurn();
@@ -59,6 +59,9 @@ public:
 
 	// Forces the draw for the next player.
 	void ForceDrawNextPhase(int sumForNextDraw);
+
+	// Sets the player that has missed uno spell check
+	void SetMissedUno(int playerId);
 private:
 	std::vector<std::shared_ptr<Command>> _turnCommands;
 	std::vector<std::shared_ptr<Player>> _players;
@@ -67,5 +70,6 @@ private:
 	int _currentPlayer = 0;
 	int _numberOfPlayers;
 	bool _forcedDraw = false;
+	int _missedUno = -1;
 	int _nextDraw = 0;
 };


### PR DESCRIPTION
Player is forced to draw the turn if he hasn't yelled uno at the end of his command